### PR TITLE
Update broken link to zplugin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want to use zsh-cmd-time I recommend using [zplugin](/../../../../Tomfrom
 
 ```
 mkdir ~/.zplugin
-git clone https://github.com/psprint/zplugin.git ~/.zplugin/bin
+git clone https://github.com/TomfromBerlin/zplugin.git ~/.zplugin/bin
 ```
 and add `zplugin load TomfromBerlin/zsh-cmd-time` to your `.zshrc` to install the plugin.
 


### PR DESCRIPTION
The former link `https://github.com/psprint/zplugin.git` did not work. It came from the original repository, but that no longer exists as it once was. That is, the link now points to my fork, since I don`t want to install other plugin managers, which are often quite bloated.