### PR TITLE
add "typeset -F SECONDS"

### DIFF
--- a/cmd-time.zsh
+++ b/cmd-time.zsh
@@ -27,6 +27,7 @@ typeset -g CMD_TIME_DIR="${0:A:h}"
 # https://wiki.zshell.dev/community/zsh_plugin_standard#standard-plugins-hash
 typeset -gA Plugins
 Plugins[cmd-time]="${0:h}"
+typeset -F SECONDS
 # Redraw prompt when terminal size changes
 TRAPWINCH() {
     zle && zle -R


### PR DESCRIPTION
"typeset -F SECONDS" has been added to the plugin so that no changes in .zshrc are necessary. The plugin now runs immediately after installation. Nevertheless, some default settings in the .zshrc file can still be overwritten.