### PR TITLE
Plugin Manager Activity Indicator

### DIFF
--- a/cmd-time.plugin.zsh
+++ b/cmd-time.plugin.zsh
@@ -5,6 +5,9 @@
 # Set $0 with a new trik - use of %x prompt expansion
 0="${ZERO:-${${${(M)${0::=${(%):-%x}}:#/*}:-$PWD/$0}:A}}"
 local ZERO="$0"
-
+# https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html#indicator
+if [[ ${zsh_loaded_plugins[-1]} != */zsh-cmd-time && -z ${fpath[(r)${0:h}]} ]] {
+    fpath+=( "${0:h}" )
+}
 source ${0:A:h}/cmd-time.zsh
 # vim:ft=zsh:tw=80:sw=4:sts=4:et:foldmarker=[[[,]]]


### PR DESCRIPTION
This will allow user to reliably source the plugin without using a plugin manager. The code uses the wrapping braces around variables (i.e.: e.g.: ${fpath…}) to make it compatible with the KSH_ARRAYS option and the quoting around ${0:h} to make it compatible with the SH_WORD_SPLIT option.
more: https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html#indicator