### PR TITLE
Bugfix

### DIFF
--- a/cmd-time.zsh
+++ b/cmd-time.zsh
@@ -2,7 +2,7 @@
 #                                                                              #
 #        Everything below this line comes with no warranty of any kind.        #
 #                     Use these file at your own risk!                         #
-# last update: 06/2023                                                         #
+# last update: 07/2023                                                         #
 ################################################################################
 #                                                                              #
 # This plugin will overwrite your existing RPS1.                               #
@@ -30,37 +30,24 @@ Plugins[cmd-time]="${0:h}"
 TRAPWINCH() {
     zle && zle -R
     }
-_command_time_preexec() {
+_cmd_time_preexec() {
   # check excluded
-  if [ -n "$ZSH_COMMAND_TIME_EXCLUDE" ]; then
-    cmd="$1"
-    for exc ($ZSH_COMMAND_TIME_EXCLUDE) do;
-      if [ "$(echo $cmd | grep -c "$exc")" -gt 0 ]; then
-        RPS1='${vcs_info_msg_0_} %(?.%F{green}√.%K{red}%F{black} Nope!)%f%k'
-        return
-      fi
-    done
-  fi
-  timer=${timer:-$SECONDS}
-  ZSH_COMMAND_TIME_MSG=${ZSH_COMMAND_TIME_MSG-"Time: %s"}
-  ZSH_COMMAND_TIME_COLOR=${ZSH_COMMAND_TIME_COLOR-"white"}
-  export ZSH_COMMAND_TIME=""
-}
-_command_time_precmd() {
-  if [ $timer ]; then timer_show=$(($SECONDS - $timer))
-    if [ -n "$TTY" ] ; then export ZSH_COMMAND_TIME="$timer_show"
-      if [ ! -z ${ZSH_COMMAND_TIME_MSG} ]; then zsh_command_time; fi
-    fi
+    [[ -n "$ZSH_CMD_TIME_EXCLUDE" ]] && for exc in $ZSH_CMD_TIME_EXCLUDE; do [ "$(echo "$1" | grep -c "$exc")" -gt 0 ] && RPS1='${vcs_info_msg_0_} %(?.%F{green}√.%K{red}%F{black} Nope!)%f%k' && return; done
+    timer=${timer:-$SECONDS}
+    timer_show=""
+    export timer_show
+    }
+_cmd_time_precmd() {
+    [[ $timer ]] && timer_show=$(($SECONDS - $timer))
+    export timer_show && zsh_cmd_time
     unset timer
-  fi
-}
-zsh_command_time() {
-  if [ -n "$ZSH_COMMAND_TIME" ]; then
-  h=$(bc -l <<< $ZSH_COMMAND_TIME/3600)
-  m=$(bc -l <<< $ZSH_COMMAND_TIME%3600/60)
-  s=$(bc -l <<< $ZSH_COMMAND_TIME%60)
-  if [[ "$timer_show" -le "1" ]]; then ZSH_CMD_TIME_COLOR="magenta" && timer_show=$(printf '%.6f'" sec" "$timer_show")
-        elif [[ "$timer_show" -le "60" ]]; then ZSH_CMD_TIME_COLOR="green" && timer_show=$(printf '%.3f'" sec" "$timer_show")
+    }
+zsh_cmd_time() {
+    if [[ -n "$timer_show" ]]; then
+# we leave the handling of floating point numbers to bc --> https://www.gnu.org/software/bc/manual/html_mono/bc.html
+        h=$(bc <<< "${timer_show}/3600") && m=$(bc <<< "(${timer_show}%3600)/60") && s=$(bc <<< "${timer_show}%60")
+        if [[ "$timer_show" -le 1 ]]; then ZSH_CMD_TIME_COLOR="magenta" && timer_show=$(printf '%.6f'" sec" "$timer_show")
+        elif [[ "$timer_show" -le 60 ]]; then ZSH_CMD_TIME_COLOR="green" && timer_show=$(printf '%.3f'" sec" "$timer_show")
 # '%.nf' defines the number of decimal places, where n is an integer. Values
 # above 14 are possible, but not useful, because the computer's internal
 # representation of floating point numbers has a limited number of bits and as
@@ -68,14 +55,14 @@ zsh_command_time() {
 # stored as e.g. 3.0000000000 in memory, but as 3.0000000002 or 2.9999999998.
 # Rounding errors are therefore unavoidable and you can safely ignore everything
 # after the 14th decimal place in a result.
-        elif [[ "$timer_show" -gt "60" ]] && [[ "$timer_show" -le "180" ]]; then ZSH_CMD_TIME_COLOR="cyan" && timer_show=$(printf '%02dm:%02ds' $((m)) $((s)))
+        elif [[ "$timer_show" -gt 60 ]] && [[ "$timer_show" -le 180 ]]; then ZSH_CMD_TIME_COLOR="cyan" && timer_show=$(printf '%02dm:%02ds' $((m)) $((s)))
         elif [[ "$h" -gt 0 ]]; then m=$((m%60)) && ZSH_CMD_TIME_COLOR="red" && timer_show=$(printf '%02dh:%02dm:%02ds' $((h)) $((m)) $((s))); else ZSH_CMD_TIME_COLOR="yellow" && timer_show=$(printf '%02dm:%02ds' $((m)) $((s)))
         fi
-    elapsed=$(echo -e "%F{$ZSH_CMD_TIME_COLOR}$(printf '%s' "${ZSH_CMD_TIME_MSG}"" $timer_show")%f")
-    export elapsed
-    RPS1='${elapsed} ${vcs_info_msg_0_} %(?.%F{green}√.%K{red}%F{black} Nope!)%f%k'
-  fi
+          elapsed=$(echo -e "%F{$ZSH_CMD_TIME_COLOR}$(printf '%s' "${ZSH_CMD_TIME_MSG}"" $timer_show")%f")
+          export elapsed
+          RPS1='${elapsed} ${vcs_info_msg_0_} %(?.%F{green}√.%K{red}%F{black} Nope!)%f%k'
+    fi
 }
-
-precmd_functions+=(_command_time_precmd)
-preexec_functions+=(_command_time_preexec)
+precmd_functions+=(_cmd_time_precmd)
+preexec_functions+=(_cmd_time_preexec)
+#


### PR DESCRIPTION
Execution times longer than 180 seconds were not displayed. This has been fixed.