### PR TITLE
Fixed bug with empty command line input

### DIFF
--- a/cmd-time.zsh
+++ b/cmd-time.zsh
@@ -38,6 +38,7 @@ _cmd_time_preexec() {
     export timer_show
     }
 _cmd_time_precmd() {
+    timer_show=""
     [[ $timer ]] && timer_show=$(($SECONDS - $timer))
     export timer_show && zsh_cmd_time
     unset timer


### PR DESCRIPTION
I experienced an issue when i enter empty command in my zsh terminal on MacOS Ventura 12.7.1, it only happens after timer_show variable is already filled with some info, see picture..

Fixed it by resetting timer_show variable to empty string in  "_cmd_time_precmd()". 

<img width="560" alt="cmd_time_err" src="https://github.com/TomfromBerlin/zsh-cmd-time/assets/103860270/c27e7f52-0a75-476b-ae43-a36371aa2063">
